### PR TITLE
JJMB-28/JJMB-29: Implemented command history and tracking

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -12,7 +12,7 @@ command_token = "!"
 command_tick_rate = 0.1
 max_multi_command_length = 200
 max_command_queue_length = 500
-message_history_length = 25
+command_history_length = 25
 
 ### Media Settings ###
 [settings.media]

--- a/src/constants.py
+++ b/src/constants.py
@@ -102,7 +102,7 @@ class MumimoCfgFields:
             TICK_RATE: str = f"{MumimoCfgSections.SETTINGS_COMMANDS}.command_tick_rate"
             MAX_MULTI_COMMAND_LENGTH: str = f"{MumimoCfgSections.SETTINGS_COMMANDS}.max_multi_command_length"
             MAX_COMMAND_QUEUE_LENGTH: str = f"{MumimoCfgSections.SETTINGS_COMMANDS}.max_command_queue_length"
-            MESSAGE_HISTORY_LENGTH: str = f"{MumimoCfgSections.SETTINGS_COMMANDS}.message_history_length"
+            COMMAND_HISTORY_LENGTH: str = f"{MumimoCfgSections.SETTINGS_COMMANDS}.command_history_length"
 
         class MEDIA:
             VOLUME: str = f"{MumimoCfgSections.SETTINGS_MEDIA}.volume"

--- a/src/corelib/command_history.py
+++ b/src/corelib/command_history.py
@@ -1,0 +1,60 @@
+from copy import deepcopy
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from .command import Command
+
+
+class CommandHistory:
+    _history: List["Command"]
+    _limit: int
+
+    DEFAULT_HISTORY_LIMIT: int = 1000
+
+    @property
+    def history(self) -> List["Command"]:
+        return self._history
+
+    @property
+    def length(self) -> int:
+        return len(self._history)
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    @limit.setter
+    def limit(self, value: int) -> None:
+        if value <= 0:
+            self._limit = self.DEFAULT_HISTORY_LIMIT
+            return
+        self._limit = value
+
+    def __init__(self, history_limit: Optional[int] = DEFAULT_HISTORY_LIMIT) -> None:
+        self._history = []
+        if history_limit is not None:
+            self.limit = history_limit
+        else:
+            self.limit = self.DEFAULT_HISTORY_LIMIT
+
+    def get_last(self, last_n: int = 1) -> List["Command"]:
+        if last_n < 1:
+            return []
+        reverse_history = list(reversed(self._history))
+        return reverse_history[:last_n]
+
+    def add(self, command: "Command") -> Optional["Command"]:
+        if self.length >= self.limit:
+            return None
+        to_add = deepcopy(command)
+        self._history.append(to_add)
+        return to_add
+
+    def pop(self, idx: int) -> Optional["Command"]:
+        try:
+            return self._history.pop(idx)
+        except IndexError:
+            return None
+
+    def clear(self) -> None:
+        self._history.clear()

--- a/src/services/cmd_processing_service.py
+++ b/src/services/cmd_processing_service.py
@@ -1,9 +1,12 @@
 from typing import TYPE_CHECKING, Optional
 
+from ..constants import MumimoCfgFields
+from ..corelib.command_history import CommandHistory
 from ..exceptions import ServiceError
 from ..logging import debug as _debug
 from ..logging import get_logger
 from ..logging import print as _print
+from ..logging import print_warning
 from ..utils import config_utils
 from ..utils.parsers import cmd_parser
 
@@ -13,14 +16,29 @@ if TYPE_CHECKING:
     from ..config import Config
     from ..corelib.command import Command
 
+
 _logger = get_logger(__name__)
 print = _print(_logger)
 debug = _debug(logger=_logger)
+warning = print_warning(logger=_logger)
 
 
 class CommandProcessingService:
     _cfg_instance: "Config"
     _connection_instance: "Mumble"
+    _cmd_history: "CommandHistory"
+
+    @property
+    def connection_instance(self) -> "Mumble":
+        return self._connection_instance
+
+    @property
+    def cfg_instance(self) -> "Config":
+        return self._cfg_instance
+
+    @property
+    def cmd_history(self) -> "CommandHistory":
+        return self._cmd_history
 
     def __init__(self, murmur_connection: "Mumble", cfg_instance: Optional["Config"] = None) -> None:
         self._connection_instance = murmur_connection
@@ -28,14 +46,15 @@ class CommandProcessingService:
             raise ServiceError("Unable to retrieve murmur connection: the murmur instance is not connected to a server.", logger=_logger)
         if cfg_instance is not None:
             self._cfg_instance = cfg_instance
-            return
-        self._cfg_instance = config_utils.get_config_instance()
-        if self.cfg_instance is None:
-            raise ServiceError("Unable to create command processing service: config instance could not be retrieved.", logger=_logger)
+        else:
+            self._cfg_instance = config_utils.get_config_instance()
+            if self.cfg_instance is None:
+                raise ServiceError("Unable to create command processing service: config instance could not be retrieved.", logger=_logger)
+        self._cmd_history = CommandHistory(history_limit=self.cfg_instance.get(MumimoCfgFields.SETTINGS.COMMANDS.COMMAND_HISTORY_LENGTH, None))
 
     def process_cmd(self, text) -> None:
         if text is None:
-            raise ServiceError("Received text message with a None value.", logger=_logger)
+            raise ServiceError("Received text message with a 'None' value.", logger=_logger)
         parsed_cmd: Optional["Command"] = cmd_parser.parse_command(text, self.cfg_instance)
         if parsed_cmd is not None:
             actor_name: str = cmd_parser.parse_actor_name(parsed_cmd, self.connection_instance)
@@ -43,13 +62,10 @@ class CommandProcessingService:
             parsed_cmd.message = cmd_parser.parse_message_image_data(parsed_cmd)
             parsed_cmd.message = cmd_parser.parse_message_hyperlink_data(parsed_cmd)
 
+            # Add command to command history:
+            if self.cmd_history is None:
+                raise ServiceError("Unable to add command to uninitialized command history.", logger=_logger)
+            if self.cmd_history.add(parsed_cmd) is None:
+                warning(f"The command: [{parsed_cmd.message}] could not be added to the command history.")
+
             debug(f"{channel_name}::{actor_name}::[Cmd:{parsed_cmd.command} | Params:{parsed_cmd.parameters}]::{parsed_cmd.message}")
-        # Refer to: https://github.com/DuckBoss/JJMumbleBot/blob/master/JJMumbleBot/core/bot_service.py
-
-    @property
-    def connection_instance(self):
-        return self._connection_instance
-
-    @property
-    def cfg_instance(self):
-        return self._cfg_instance

--- a/tests/core/test_client_state.py
+++ b/tests/core/test_client_state.py
@@ -18,6 +18,11 @@ class TestClientState:
         client_state = ClientState(mumble_instance)
         assert client_state.audio_properties is not None
 
+    @patch.object(MurmurConnection, "connection_instance")
+    def test_cmd_service_init(self, mumble_instance: Mumble) -> None:
+        client_state = ClientState(mumble_instance)
+        assert client_state.cmd_service is not None
+
 
 class TestAudioState:
     def test_audio_state_init(self) -> None:

--- a/tests/corelib/test_command_history.py
+++ b/tests/corelib/test_command_history.py
@@ -1,0 +1,124 @@
+from typing import List, Optional
+
+import pytest
+
+from src.corelib.command import Command
+from src.corelib.command_history import CommandHistory
+
+
+class TestCommandHistory:
+    @pytest.fixture(autouse=True)
+    def mock_cmd_history_list(self) -> List[Command]:
+        history: List[Command] = [
+            Command("test_1", ["param_1", "param_2"], "test_msg_1"),
+            Command("test_2", ["param_1", "param_2"], "test_msg_2"),
+            Command("test_3", ["param_1", "param_2"], "test_msg_3"),
+            Command("test_4", ["param_1", "param_2"], "test_msg_4"),
+        ]
+        return history
+
+    @pytest.fixture(autouse=True)
+    def mock_empty_cmd_history(self) -> CommandHistory:
+        history: CommandHistory = CommandHistory()
+        return history
+
+    @pytest.fixture(autouse=True)
+    def mock_filled_cmd_history(self, mock_cmd_history_list) -> CommandHistory:
+        history: CommandHistory = CommandHistory()
+        for cmd in mock_cmd_history_list:
+            history.add(cmd)
+        return history
+
+    class TestCommandHistoryInit:
+        def test_command_history_init(self) -> None:
+            history: CommandHistory = CommandHistory()
+            assert history is not None
+
+        def test_command_history_init_with_limit(self) -> None:
+            history: CommandHistory = CommandHistory(history_limit=10)
+            assert history is not None
+            assert history.limit == 10
+
+        def test_command_history_init_with_invalid_limit(self) -> None:
+            history: CommandHistory = CommandHistory(history_limit=-5)
+            assert history is not None
+            assert history.limit == CommandHistory.DEFAULT_HISTORY_LIMIT
+
+        def test_command_history_init_with_none_limit(self) -> None:
+            history: CommandHistory = CommandHistory(history_limit=None)
+            assert history is not None
+            assert history.limit == CommandHistory.DEFAULT_HISTORY_LIMIT
+
+    class TestCommandHistoryProperties:
+        def test_command_history_history_property(self, mock_filled_cmd_history: CommandHistory) -> None:
+            history: CommandHistory = mock_filled_cmd_history
+            assert history.history is not None
+
+        def test_command_history_length_property(self, mock_filled_cmd_history: CommandHistory, mock_cmd_history_list: List[Command]) -> None:
+            history: CommandHistory = mock_filled_cmd_history
+            assert history.length == len(mock_cmd_history_list)
+
+        def test_command_history_limit_property(self, mock_empty_cmd_history: CommandHistory) -> None:
+            history: CommandHistory = mock_empty_cmd_history
+            assert history.limit == mock_empty_cmd_history.DEFAULT_HISTORY_LIMIT
+
+    class TestCommandHistorySetters:
+        def test_command_history_limit_setter_valid_limit(self, mock_empty_cmd_history: CommandHistory) -> None:
+            history: CommandHistory = mock_empty_cmd_history
+            history.limit = 10
+            assert history.limit == 10
+
+        def test_command_history_limit_setter_invalid_limit(self, mock_empty_cmd_history: CommandHistory) -> None:
+            history: CommandHistory = mock_empty_cmd_history
+            history.limit = -5
+            assert history.limit == mock_empty_cmd_history.DEFAULT_HISTORY_LIMIT
+
+    class TestCommandHistoryMethods:
+        class TestGetLast:
+            def test_command_history_get_last_valid(self, mock_filled_cmd_history: CommandHistory) -> None:
+                history: CommandHistory = mock_filled_cmd_history
+                history.add(Command("test_5", message="test_msg_5"))
+                cmd_result: List[Command] = history.get_last(1)
+                assert cmd_result
+                assert cmd_result[0].command == "test_5"
+
+            def test_command_history_get_last_invalid_last_n(self, mock_filled_cmd_history: CommandHistory) -> None:
+                history: CommandHistory = mock_filled_cmd_history
+                cmd_result: List[Command] = history.get_last(0)
+                assert not cmd_result
+
+            def test_command_history_get_last_with_empty_history(self, mock_empty_cmd_history: CommandHistory) -> None:
+                history: CommandHistory = mock_empty_cmd_history
+                cmd_result: List[Command] = history.get_last(0)
+                assert not cmd_result
+
+        class TestAdd:
+            def test_command_history_add(self, mock_filled_cmd_history) -> None:
+                history: CommandHistory = mock_filled_cmd_history
+                cmd_result: Optional[Command] = history.add(Command("test_5", message="test_msg_5"))
+                assert cmd_result is not None
+                assert cmd_result.command == "test_5"
+
+            def test_command_history_add_above_limit_fails(self, mock_filled_cmd_history) -> None:
+                history: CommandHistory = mock_filled_cmd_history
+                mock_filled_cmd_history.limit = mock_filled_cmd_history.length
+                cmd_result: Optional[Command] = history.add(Command("test_5", message="test_msg_5"))
+                assert cmd_result is None
+
+        class TestPop:
+            def test_command_history_pop_valid_index(self, mock_filled_cmd_history: CommandHistory) -> None:
+                history: CommandHistory = mock_filled_cmd_history
+                cmd_result: Optional[Command] = history.pop(0)
+                assert cmd_result is not None
+                assert cmd_result.command == "test_1"
+
+            def test_command_history_pop_invalid_index(self, mock_filled_cmd_history: CommandHistory) -> None:
+                history: CommandHistory = mock_filled_cmd_history
+                cmd_result: Optional[Command] = history.pop(999)
+                assert cmd_result is None
+
+        class TestClear:
+            def test_command_history_clear(self, mock_filled_cmd_history) -> None:
+                history: CommandHistory = mock_filled_cmd_history
+                history.clear()
+                assert len(history.history) == 0

--- a/tests/services/test_cmd_processing_service.py
+++ b/tests/services/test_cmd_processing_service.py
@@ -11,13 +11,15 @@ class TestCommandProcessingService:
     @pytest.fixture(autouse=True)
     @patch("src.config.Config")
     @patch("pymumble_py3.mumble.Mumble")
-    def get_cmd_processing_service(self, mock_mumble, mock_config):
+    def get_cmd_processing_service(self, mock_mumble, mock_config) -> CommandProcessingService:
+        mock_config.get.return_value = 10
         return CommandProcessingService(mock_mumble, mock_config)
 
     class TestServiceInit:
         @patch("src.config.Config")
         @patch("pymumble_py3.mumble.Mumble")
         def test_init_command_processing_service(self, mock_mumble, mock_config) -> None:
+            mock_config.get.return_value = 10
             service: CommandProcessingService = CommandProcessingService(mock_mumble, mock_config)
             assert service is not None
 
@@ -44,6 +46,18 @@ class TestCommandProcessingService:
         @patch("src.services.cmd_processing_service.debug")
         @patch("src.utils.parsers.cmd_parser.parse_command")
         def test_process_cmd_valid_text(self, mock_parse_command, mock_debug, mock_connection_instance, get_cmd_processing_service) -> None:
+            mock_debug.return_value = None
+            mock_connection_instance.return_value = self.MockMumble()
+            mock_parse_command.return_value = Command("test_cmd", ["param_1", "param_2"], "test_msg", 0, 0, -1)
+            service: CommandProcessingService = get_cmd_processing_service
+            assert service.process_cmd("") is None
+
+        @patch("src.services.cmd_processing_service.CommandProcessingService.connection_instance", new_callable=PropertyMock)
+        @patch("src.services.cmd_processing_service.debug")
+        @patch("src.utils.parsers.cmd_parser.parse_command")
+        def test_process_cmd_valid_text_cmd_history_is_none(
+            self, mock_parse_command, mock_debug, mock_connection_instance, get_cmd_processing_service
+        ) -> None:
             mock_debug.return_value = None
             mock_connection_instance.return_value = self.MockMumble()
             mock_parse_command.return_value = Command("test_cmd", ["param_1", "param_2"], "test_msg", 0, 0, -1)


### PR DESCRIPTION
- Renamed cfg option: 'message_history_length' to 'command_history_length'
- Added command history and command usage tracking.
- Added unit tests.